### PR TITLE
add install CUDA host driver

### DIFF
--- a/singularity/install_dependencies.sh
+++ b/singularity/install_dependencies.sh
@@ -8,11 +8,18 @@ sudo apt-get install -y \
     uuid-dev \
     uidmap \
     libssl-dev \
-    libgpgme-dev \ #only for ubuntu18.04 or later
+    libgpgme-dev \
     squashfs-tools \
     libseccomp-dev \
     wget \
     pkg-config \
     git \
-    cryptsetup-bin 
+    cryptsetup-bin
 
+# Install CUDA 10.2 host driver for base image to use.
+wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/cuda-ubuntu1804.pin
+sudo mv cuda-ubuntu1804.pin /etc/apt/preferences.d/cuda-repository-pin-600
+sudo apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/7fa2af80.pub
+sudo add-apt-repository "deb http://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/ /"
+sudo apt-get update
+sudo apt-get -y install cuda


### PR DESCRIPTION
Container using images with driver version >= 10.2 need similar driver on the
host. CUDA is usually backward-compatible. So it is OK to install the latest
version on the host and the containers use equally new or older version. The
reverse doesn't work: Newer driver version in the containers is not runnable
if host driver is older.