### PR TITLE
Add README for build and tweak Makefile for faster subsequent builds

### DIFF
--- a/singularity/Makefile
+++ b/singularity/Makefile
@@ -1,6 +1,8 @@
-all:
-	singularity build --fakeroot -F covid19_1.5.sif covid19_base.singularity
+all: covid19_1.5.sif
 	singularity build --fakeroot -F covid19_latest.sif covid19.singularity
+
+covid19_1.5.sif:
+	singularity build --fakeroot -F covid19_1.5.sif covid19_base.singularity
 
 clean:
 	rm -f covid19_1.5.sif

--- a/singularity/README.md
+++ b/singularity/README.md
@@ -1,0 +1,7 @@
+# Build guide
+
+It is advisable to use GNU `make` command to build:
+
+Just run `make` at the directory where this README.md file is located. On the first-time build, `make` will build the base image as well. On the subsequent builds, when base image (covid19_1.5.sif) already exists, `make` will go ahead and build other parts. 
+
+In case you make some changes on the base defition file, `make clean` and then `make` will clean up and build from srcatch. This will take more time.  


### PR DESCRIPTION
Tweak makefile to avoid rebuilding the base image and speed up building process.